### PR TITLE
Add validation error message

### DIFF
--- a/app/assets/javascripts/messages.coffee
+++ b/app/assets/javascripts/messages.coffee
@@ -1,6 +1,9 @@
 $(document).on 'submit', '.new_message', ->
   body = $('textarea').val()
-  return false if body is ''
+
+  if body is ''
+    $('.validation-error').addClass('visible').attr('aria-hidden', false)
+    return false
 
   secret = UUID()
   encrypted = CryptoJS.AES.encrypt(body, secret)

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -138,15 +138,15 @@ strong
 .validation-error
   background: $c-yellow
   border-bottom: 1px solid $c-light
-  display: none
   margin-top: -50px
   padding: 20px 10px 10px
   text-align: center
   transition: margin-top .5s cubic-bezier(0, 1.3, .5, 1.3)
+  visibility: hidden
 
   &.visible
-    display: block
     margin-top: -10px
+    visibility: visible
 
 .new-message-field
   background: $c-white

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -135,6 +135,19 @@ strong
 
 // New message
 
+.validation-error
+  background: $c-yellow
+  border-bottom: 1px solid $c-light
+  display: none
+  margin-top: -50px
+  padding: 20px 10px 10px
+  text-align: center
+  transition: margin-top .5s cubic-bezier(0, 1.3, .5, 1.3)
+
+  &.visible
+    display: block
+    margin-top: -10px
+
 .new-message-field
   background: $c-white
   border: none

--- a/app/views/messages/new.html.haml
+++ b/app/views/messages/new.html.haml
@@ -1,3 +1,5 @@
+%div.validation-error(aria-hidden role='alert')= t('validation-error')
+
 %textarea.new-message-field(autofocus placeholder="#{t('new-message.placeholder')}" maxlength=16384 name='body')
 
 = form_for @message do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,10 @@ en:
     icon-title: Lock icon
     button-text: Create message
 
+  # Validation Error
+
+  validation-error: Your message is empty. Type something before creating it.
+
   # Link page
 
   created-message:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -253,6 +253,10 @@ pt:
     icon-title: Ícone de cadeado
     button-text: Criar mensagem
 
+  # Validation Error
+
+  validation-error: Sua mensagem está vazia. Digite alguma coisa antes de criá-la.
+
   # Link page
 
   created-message:


### PR DESCRIPTION
Pra mostrar a mensagem, tem que adicionar a classe `.visible` e remover o atributo `aria-hidden` (acessibilidade) do elemento `.validation-error`.

Pra esconder, faz o contrário: remove a classe `.visible` e volta com o atributo `aria-hidden`.

Também pode fazer o atributo `aria-hidden` ter valor `true` ou `false`, ao invés de removê-lo.