### PR TITLE
Add support for JSON

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,6 +7,10 @@ class MessagesController < ApplicationController
 
   def create
     @message = Message.create(message_params)
+    respond_to do |format|
+      format.html
+      format.json { render json: @message.to_json(only: :id) }
+    end
   end
 
   def show
@@ -16,7 +20,16 @@ class MessagesController < ApplicationController
   end
 
   def destroy
-    @message = Message.destroy(params[:id])
+    respond_to do |format|
+      begin
+        @message = Message.destroy(params[:id])
+        format.html
+        format.json { render json: @message.to_json(only: :data) }
+      rescue ActiveRecord::RecordNotFound
+        format.html { render 'missing' }
+        format.json { render json: { error: 'Not found' } }
+      end
+    end
   end
 
   private

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,37 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe MessagesController, type: :controller do
+  context 'HTML' do
+    describe 'GET #new' do
+      it 'returns HTTP success' do
+        get :new
+        expect(response).to have_http_status(:success)
+      end
+    end
 
-  describe 'GET #new' do
-    it 'returns http success' do
-      get :new
-      expect(response).to have_http_status(:success)
+    describe 'POST #create' do
+      it 'returns HTTP success' do
+        post :create, message: { data: '....' }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe 'GET #show' do
+      before { allow(Message).to receive(:find) { double }}
+
+      it 'returns HTTP success' do
+        get :show, id: 1
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      before { allow(Message).to receive(:destroy) { double }}
+
+      it 'returns HTTP success' do
+        delete :destroy, id: 1
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 
-  describe 'POST #create' do
-    it 'returns http success' do
-      post :create, message: { data: '....' }
-      expect(response).to have_http_status(:success)
+  context 'JSON' do
+    describe 'POST #create' do
+      it 'returns HTTP success' do
+        post :create, message: { data: '....' }, format: :json
+        body = JSON.parse(response.body)
+        expect(response).to have_http_status(:success)
+        expect(body['id'].size > 0).to be true
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'returns raw data' do
+        m = Message.create(data: '...')
+        delete :destroy, id: m.id, format: :json
+        body = JSON.parse(response.body)
+        expect(response).to have_http_status(:success)
+        expect(body['data'].size > 0).to be true
+      end
+
+      it "returns error when message doesn't exist" do
+        delete :destroy, id: 'INXESISTENT', format: :json
+        body = JSON.parse(response.body)
+        expect(response).to have_http_status(:success)
+        expect(body['error']).to eq 'Not found'
+      end
     end
   end
-
-  describe 'GET #show' do
-    before { allow(Message).to receive(:find) { double }}
-
-    it 'returns http success' do
-      get :show, id: 1
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe 'DELETE #destroy' do
-    before { allow(Message).to receive(:destroy) { double }}
-
-    it 'returns http success' do
-      delete :destroy, id: 1
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end


### PR DESCRIPTION
Hi guys!

I've been working on a CLI for Vuash written in Crystal, you can check it [here](https://github.com/hugoabonizio/vuash-cli). It's still a WIP, depending on this support.

Following #93, I added JSON support to `messages#create` and `messages#destroy` actions to make communication with CLI easier. WDYT?

For now, there's a limitation where messages created by the website and CLI aren't interchangeable. I think this is due to different cipher algorithms, or the lacking of IV. The Crystal code is really close to Ruby, so it's easy to understand, and I would appreciate some feedback. :smile: