### PR TITLE
Remove deprecated Heroku badge, add donation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 # Vuash
 
-[![Heroku](https://heroku-badge.herokuapp.com/?app=vuash&style=flat)](http://vuash.herokuapp.com)
 [![GitHub release](https://img.shields.io/github/release/current/vuash.svg)](https://github.com/current/vuash/releases/latest)
 
 Vuash is a simple web app that lets you share plain text through a single access link.
@@ -34,3 +33,10 @@ All encryption is done by the browser, no secret keys touch the server, and only
 ## Hosted app
 
 The app running at http://vua.sh is hosted on Heroku, with automatic deploys from this [master branch](https://github.com/current/vuash/tree/master/). Production code is always paired with this repository.
+
+
+## Support the project
+
+We currently pay for Vuash's domain from our own pocket. Please consider donating :balloon:
+
+[![Buy Me a Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/rmasoni)


### PR DESCRIPTION
## Purpose

Heroku badge is offline, the project has probably been abandoned. Also, we need some easy way for people to donate.


## Approach

Remove Heroku badge. Add donation link.
